### PR TITLE
Hold reference to intercepted Logger to prevent GC wiping out the int…

### DIFF
--- a/logunit-jul/src/main/java/io/github/netmikey/logunit/jul/JulLogProvider.java
+++ b/logunit-jul/src/main/java/io/github/netmikey/logunit/jul/JulLogProvider.java
@@ -23,6 +23,10 @@ public class JulLogProvider extends BaseLogProvider {
 
     private final ListHandler listHandler = new ListHandler();
 
+    // We hold references to loggers we have intercepted to avoid them being garbage collected and reconstructed without
+    // our handler in between beforeTestExecution and the actual test business logic.
+    private final Map<String, Logger> loggers = new HashMap<>();
+
     private final Map<String, Level> originalLevels = new HashMap<>();
 
     @Override
@@ -65,6 +69,7 @@ public class JulLogProvider extends BaseLogProvider {
 
     private void addAppenderToLogger(Logger logger, Level level) {
         logger.addHandler(listHandler);
+        loggers.put(logger.getName(), logger);
         originalLevels.put(logger.getName(), logger.getLevel());
         logger.setLevel(level);
     }
@@ -75,6 +80,7 @@ public class JulLogProvider extends BaseLogProvider {
 
     private void detachAppenderFromLogger(Logger logger) {
         logger.removeHandler(listHandler);
+        loggers.remove(logger.getName());
         Level originalLevel = originalLevels.get(logger.getName());
         if (originalLevel != null) {
             logger.setLevel(originalLevel);

--- a/logunit-jul/src/test/java/io/github/netmikey/logunit/jul/LogCapturerWithJulTest.java
+++ b/logunit-jul/src/test/java/io/github/netmikey/logunit/jul/LogCapturerWithJulTest.java
@@ -86,8 +86,8 @@ public class LogCapturerWithJulTest {
         logger.severe("Some severe message");
     }
 
-    // The logger will not be until the object is. This tests that log messages will be captured without allowing
-    // the intercepted Logger to be garbage collected.
+    // The logger will not be constructed until the object is. This tests that log messages will be captured
+    // without allowing the intercepted Logger to be garbage collected.
     private static class LoggingObject {
         Logger testLogger = Logger.getLogger(LoggingObject.class.getName());
     }

--- a/logunit-jul/src/test/java/io/github/netmikey/logunit/jul/LogCapturerWithJulTest.java
+++ b/logunit-jul/src/test/java/io/github/netmikey/logunit/jul/LogCapturerWithJulTest.java
@@ -19,14 +19,12 @@ import io.github.netmikey.logunit.api.LogCapturer;
 public class LogCapturerWithJulTest {
 
     @RegisterExtension
-    LogCapturer testLoggerInfoCapturer = LogCapturer.create().captureForType(LogCapturerWithJulTest.class);
+    LogCapturer testLoggerInfoCapturer = LogCapturer.create().captureForType(LoggingObject.class);
 
     @RegisterExtension
     LogCapturer namedLoggerWarnCapturer = LogCapturer.create().captureForLogger(LOGGER_NAME, Level.WARN);
 
     private static final String LOGGER_NAME = "CUSTOM_LOGGER";
-
-    private Logger testLogger = Logger.getLogger(LogCapturerWithJulTest.class.getName());
 
     private Logger namedLogger = Logger.getLogger(LOGGER_NAME);
 
@@ -38,11 +36,15 @@ public class LogCapturerWithJulTest {
      * <li>that the namedLogger (by logger name) captures only the WARN level
      * and above as specified</li>
      * <li>both loggers and their capturers don't affeact each other</li>
+     * <li>logger is not garbage collected, losing interception</li>
      * </ul>
      */
     @Test
-    public void test1CaptureMessages() {
-        logEverythingOnce(testLogger);
+    public void test1CaptureMessages() throws InterruptedException {
+        System.gc();
+        Thread.sleep(50);
+
+        logEverythingOnce(new LoggingObject().testLogger);
         logEverythingOnce(namedLogger);
 
         Assertions.assertEquals(3, testLoggerInfoCapturer.size(),
@@ -82,5 +84,11 @@ public class LogCapturerWithJulTest {
         logger.info("Some info message");
         logger.warning("Some warning message");
         logger.severe("Some severe message");
+    }
+
+    // The logger will not be until the object is. This tests that log messages will be captured without allowing
+    // the intercepted Logger to be garbage collected.
+    private static class LoggingObject {
+        Logger testLogger = Logger.getLogger(LoggingObject.class.getName());
     }
 }


### PR DESCRIPTION
…erception.

JUL only holds weak references to initialized Loggers - it's fairly possible for even a `static final Logger` reference to not actually have been made when the `LogCapturer` extension runs as that will happen quite lazily when the business logic class is classloaded at some point. For a non-static reference it is even more likely. In this case, the `Logger` which had an appender added will have been garbage collected and lost, and the test will run with a new `Logger` with no interception

This adds storage of intercepted loggers only to keep a strong reference to prevent them from being garbage collected. This ensures that the same logger is used from `beforeTestExecution`, the test itself, and `afterTestExecution` and is probably the only way to reliably intercept the loggers.