### PR TITLE
Dependency Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin/
 .recommenders/
 .classpath
 .project
+.idea/

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ subprojects {
     java.toolchain.languageVersion = JavaLanguageVersion.of(8)
 
     ext {
-        junitVersion   = '5.8.2'  // https://search.maven.org/artifact/org.junit.jupiter/junit-jupiter-api
+        junitVersion   = '5.9.3'  // https://search.maven.org/artifact/org.junit.jupiter/junit-jupiter-api
         logbackVersion = '1.3.7'  // https://search.maven.org/artifact/ch.qos.logback/logback-core
         log4j2Version  = '2.20.0' // https://search.maven.org/artifact/org.apache.logging.log4j/log4j-core
         slf4jVersion   = '2.0.7'  // https://search.maven.org/artifact/org.slf4j/slf4j-api

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ subprojects {
     ext {
         junitVersion   = '5.8.2'  // https://search.maven.org/artifact/org.junit.jupiter/junit-jupiter-api
         logbackVersion = '1.3.7'  // https://search.maven.org/artifact/ch.qos.logback/logback-core
-        log4j2Version  = '2.17.1' // https://search.maven.org/artifact/org.apache.logging.log4j/log4j-core
+        log4j2Version  = '2.20.0' // https://search.maven.org/artifact/org.apache.logging.log4j/log4j-core
         slf4jVersion   = '2.0.7'  // https://search.maven.org/artifact/org.slf4j/slf4j-api
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,9 @@ subprojects {
 
     ext {
         junitVersion   = '5.8.2'  // https://search.maven.org/artifact/org.junit.jupiter/junit-jupiter-api
-        logbackVersion = '1.2.10' // https://search.maven.org/artifact/ch.qos.logback/logback-core
+        logbackVersion = '1.3.7'  // https://search.maven.org/artifact/ch.qos.logback/logback-core
         log4j2Version  = '2.17.1' // https://search.maven.org/artifact/org.apache.logging.log4j/log4j-core
-        slf4jVersion   = '1.7.32' // https://search.maven.org/artifact/org.slf4j/slf4j-api
+        slf4jVersion   = '2.0.7'  // https://search.maven.org/artifact/org.slf4j/slf4j-api
     }
 
     repositories {

--- a/logunit-jul/src/main/java/io/github/netmikey/logunit/jul/JulLogProvider.java
+++ b/logunit-jul/src/main/java/io/github/netmikey/logunit/jul/JulLogProvider.java
@@ -1,8 +1,6 @@
 package io.github.netmikey.logunit.jul;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -11,6 +9,7 @@ import java.util.stream.StreamSupport;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Marker;
+import org.slf4j.event.KeyValuePair;
 import org.slf4j.event.LoggingEvent;
 
 import io.github.netmikey.logunit.api.LogCapturer;
@@ -114,8 +113,27 @@ public class JulLogProvider extends BaseLogProvider {
             }
 
             @Override
+            public List<Object> getArguments() {
+                Object[] parameters = record.getParameters();
+                if (null == parameters) {
+                    return Collections.emptyList();
+                }
+                return Arrays.asList(parameters);
+            }
+
+            @Override
+            public List<KeyValuePair> getKeyValuePairs() {
+                return Collections.emptyList();
+            }
+
+            // for compatibility with older apis
             public Marker getMarker() {
                 return null;
+            }
+
+            @Override
+            public List<Marker> getMarkers() {
+                return Collections.emptyList();
             }
 
             @Override

--- a/logunit-jul/src/test/java/io/github/netmikey/logunit/jul/LogCapturerWithJulTest.java
+++ b/logunit-jul/src/test/java/io/github/netmikey/logunit/jul/LogCapturerWithJulTest.java
@@ -1,5 +1,8 @@
 package io.github.netmikey.logunit.jul;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.logging.Logger;
 
 import org.junit.jupiter.api.Assertions;
@@ -10,6 +13,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.event.Level;
 
 import io.github.netmikey.logunit.api.LogCapturer;
+import org.slf4j.event.LoggingEvent;
 
 /**
  * Unit test that uses JUL, applies {@link LogCapturer}s and validates their
@@ -77,6 +81,37 @@ public class LogCapturerWithJulTest {
     public void test2CapturerReset() {
         Assertions.assertEquals(0, testLoggerInfoCapturer.size());
         Assertions.assertEquals(0, namedLoggerWarnCapturer.size());
+    }
+
+    @Test
+    void test3EventMethodsWithoutParameters() {
+        namedLogger.warning(() -> "Test-Message");
+
+        List<LoggingEvent> events = namedLoggerWarnCapturer.getEvents();
+        Assertions.assertEquals(events.size(), 1);
+
+        LoggingEvent event = events.get(0);
+        Assertions.assertEquals("Test-Message", event.getMessage());
+        Assertions.assertEquals(Level.WARN, event.getLevel());
+        Assertions.assertSame(Collections.emptyList(), event.getArguments());
+        Assertions.assertSame(Collections.emptyList(), event.getKeyValuePairs());
+        Assertions.assertSame(Collections.emptyList(), event.getMarkers());
+    }
+
+    @Test
+    void test4EventMethodsWithParameters() {
+        namedLogger.log(java.util.logging.Level.SEVERE, "{0}-Message {1}", new Object[]{"Test", 42});
+
+        List<LoggingEvent> events = namedLoggerWarnCapturer.getEvents();
+        Assertions.assertEquals(events.size(), 1);
+
+        LoggingEvent event = events.get(0);
+        Assertions.assertEquals("{0}-Message {1}", event.getMessage(),
+                "returns the raw message (*not* formatted)");
+        Assertions.assertEquals(Level.ERROR, event.getLevel());
+        Assertions.assertEquals(Arrays.asList("Test", 42), event.getArguments());
+        Assertions.assertSame(Collections.emptyList(), event.getKeyValuePairs());
+        Assertions.assertSame(Collections.emptyList(), event.getMarkers());
     }
 
     private void logEverythingOnce(Logger logger) {

--- a/logunit-log4j2/build.gradle
+++ b/logunit-log4j2/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     implementation("org.apache.logging.log4j:log4j-core:${log4j2Version}")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junitVersion}")
-    testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:${log4j2Version}")
+    testRuntimeOnly("org.apache.logging.log4j:log4j-slf4j2-impl:${log4j2Version}")
 }

--- a/logunit-log4j2/src/main/java/io/github/netmikey/logunit/log4j2/Log4j2LogProvider.java
+++ b/logunit-log4j2/src/main/java/io/github/netmikey/logunit/log4j2/Log4j2LogProvider.java
@@ -81,7 +81,13 @@ public class Log4j2LogProvider extends BaseLogProvider {
         Configuration cfg = ctx.getConfiguration();
         AppenderRef ref = AppenderRef.createAppenderRef(listAppender.getName(), null, null);
         AppenderRef[] refs = new AppenderRef[] { ref };
-        LoggerConfig loggerConfig = LoggerConfig.createLogger(true, level, loggerName, "true", refs, null, cfg, null);
+        LoggerConfig loggerConfig = LoggerConfig.newBuilder()
+            .withAdditivity(true)
+            .withLevel(level)
+            .withLoggerName(loggerName)
+            .withIncludeLocation("true")
+            .withRefs(refs).withConfig(cfg)
+            .build();
         loggerConfig.addAppender(listAppender, level, null);
         cfg.addLogger(loggerConfig.getName(), loggerConfig);
     }

--- a/logunit-logback/src/main/java/io/github/netmikey/logunit/logback/LogbackLogProvider.java
+++ b/logunit-logback/src/main/java/io/github/netmikey/logunit/logback/LogbackLogProvider.java
@@ -1,5 +1,6 @@
 package io.github.netmikey.logunit.logback;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -9,6 +10,7 @@ import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
+import org.slf4j.event.KeyValuePair;
 import org.slf4j.event.LoggingEvent;
 
 import ch.qos.logback.classic.Level;
@@ -24,7 +26,7 @@ import io.github.netmikey.logunit.core.BaseLogProvider;
  */
 public class LogbackLogProvider extends BaseLogProvider {
 
-    private final ConcurrentListAppender<ILoggingEvent> listAppender = new ConcurrentListAppender<ILoggingEvent>();
+    private final ConcurrentListAppender<ILoggingEvent> listAppender = new ConcurrentListAppender<>();
 
     private final Map<String, Level> originalLevels = new HashMap<>();
 
@@ -127,8 +129,25 @@ public class LogbackLogProvider extends BaseLogProvider {
             }
 
             @Override
+            public List<Object> getArguments() {
+                return Arrays.asList(iEvent.getArgumentArray());
+            }
+
+            @Override
+            public List<KeyValuePair> getKeyValuePairs() {
+                return iEvent.getKeyValuePairs();
+            }
+
+            // for compatibility with older apis
             public Marker getMarker() {
-                return iEvent.getMarker();
+                @SuppressWarnings("deprecation")
+                Marker marker = iEvent.getMarker();
+                return marker;
+            }
+
+            @Override
+            public List<Marker> getMarkers() {
+                return iEvent.getMarkerList();
             }
 
             @Override


### PR DESCRIPTION
Using logunit with a recent logback toolchain causes RuntimeExceptions like:
```
Receiver class io.github.netmikey.logunit.logback.LogbackLogProvider$1 does not define or inherit an implementation of the resolved method 'abstract java.util.List getKeyValuePairs()' of interface org.slf4j.event.LoggingEvent
```
This PR adds support for the new features of slf4j Version 2 and Logback 1.3/1.4, while maintaining compatibility with Java 8. It also updates Log4j and JUnit.